### PR TITLE
Integration tests

### DIFF
--- a/test/integration/DeployRaffleTest.t.sol
+++ b/test/integration/DeployRaffleTest.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+import {DeployRaffle} from "../../script/DeployRaffle.s.sol";
+import {Raffle} from "../../src/Raffle.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract IntegrationsTest is Test {
+    function testDeployRaffle() public {
+        // Arrange
+        DeployRaffle deployer = new DeployRaffle();
+
+        // Act
+        (Raffle raffle, ) = deployer.run();
+
+        // Assert
+        assert(address(raffle) != address(0));
+    }
+}

--- a/test/integration/InteractionsTest.t.sol
+++ b/test/integration/InteractionsTest.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {CreateSubscription, FundSubscription, AddConsumer} from "../../script/Interactions.s.sol";
+
+contract IntegrationsTest is Test {
+    modifier skipFork() {
+        if (block.chainid != 31337) {
+            return;
+        }
+        _;
+    }
+
+    function testInteractions() public skipFork {
+        // HelperConfig helperConfig = new HelperConfig();
+        // (
+        //     ,
+        //     ,
+        //     address vrfCoordinator,
+        //     ,
+        //     ,
+        //     ,
+        //     address link,
+        //     uint256 deployerKey
+        // ) = helperConfig.activeNetworkConfig();
+        CreateSubscription createSubscription = new CreateSubscription();
+        // FundSubscription fundSubscription = new FundSubscription();
+
+        uint64 subId = createSubscription.run();
+        // vm.recordLogs();
+        // fundSubscription.run();
+        // Vm.Log[] memory entries = vm.getRecordedLogs();
+        // bytes32 subscriptionBalance = entries[0].topics[3];
+
+        assert(subId != uint64(0));
+        // assert(uint256(subscriptionBalance) == 3 ether);
+    }
+}


### PR DESCRIPTION
Hello!

I wrote some integration tests. Please check if they are ok.

I am dealing with some difficulties in testing the FundSubscription contract. The code for testing it is commented out as you can see. I will change it and push again based on feedback.
The test was reverting with the InvalidSubscription() error from VRFCoordinatorV2Mock. Upon investigation, I found that the error is triggered in the fundSubscription method when the owner of a subscription is address(0). Here is the snippet from VRFCoordinatorV2Mock:
```solidity
function fundSubscription(uint64 _subId, uint96 _amount) public {
    if (s_subscriptions[_subId].owner == address(0)) {
      revert InvalidSubscription();
    }
    uint96 oldBalance = s_subscriptions[_subId].balance;
    s_subscriptions[_subId].balance += _amount;
    emit SubscriptionFunded(_subId, oldBalance, oldBalance + _amount);
  }
```
Now, the question is how can the owner of the subscriptionId be address(0) when the subscription was created successfully as indicated by the uncommented assert (that assert is passing)? Can someone provide their valuable opinion on how I might implement the interactions test successfully?