### PR TITLE
Modulo example typo fixed in ExampleModulo.sol

### DIFF
--- a/src/sublesson/ExampleModulo.sol
+++ b/src/sublesson/ExampleModulo.sol
@@ -6,7 +6,7 @@ contract ExampleModulo {
     function getModTen(uint256 number) external pure returns (uint256) {
         // 10 % 10 = 0
         // 10 % 9 = 1 (10 / 9 = 1.??)
-        // 2 % 2 = 0. 2 % 3 = 1.   2 % 6 = 0. 2 % 7 = 1
+        // 2 % 2 = 0. 3 % 2 = 1.   6 % 2 = 0. 7 % 2 = 1
         return number % 10;
     }
 


### PR DESCRIPTION
Fixed a small typing error made while explaining the Modulo operation on 2 through example comments.

File : [/src/sublesson/ExampleModulo.sol](https://github.com/Cyfrin/foundry-smart-contract-lottery-f23/blob/main/src/sublesson/ExampleModulo.sol)