### PR TITLE
set RaffleState to be OPEN only AFTER  money is already sent to the w…

### DIFF
--- a/src/Raffle.sol
+++ b/src/Raffle.sol
@@ -173,10 +173,10 @@ contract Raffle is VRFConsumerBaseV2, AutomationCompatibleInterface {
         address payable recentWinner = s_players[indexOfWinner];
         s_recentWinner = recentWinner;
         s_players = new address payable[](0);
-        s_raffleState = RaffleState.OPEN;
         s_lastTimeStamp = block.timestamp;
         emit WinnerPicked(recentWinner);
         (bool success, ) = recentWinner.call{value: address(this).balance}("");
+        s_raffleState = RaffleState.OPEN;
         // require(success, "Transfer failed");
         if (!success) {
             revert Raffle__TransferFailed();


### PR DESCRIPTION
Set RaffleState to be OPEN only AFTER  money is already sent to the winner, to prevent adding other players before money is sent.

Solution to this issue -> https://github.com/Cyfrin/foundry-smart-contract-lottery-f23/issues/39