### PR TITLE
Update Raffle.sol constructor, clear balance when deploying #29 #42

### DIFF
--- a/src/Raffle.sol
+++ b/src/Raffle.sol
@@ -87,6 +87,7 @@ contract Raffle is VRFConsumerBaseV2, AutomationCompatibleInterface {
         s_raffleState = RaffleState.OPEN;
         s_lastTimeStamp = block.timestamp;
         i_callbackGasLimit = callbackGasLimit;
+        payable(msg.sender).transfer(address(this).balance);
     }
 
     function enterRaffle() public payable {

--- a/src/Raffle.sol
+++ b/src/Raffle.sol
@@ -87,7 +87,10 @@ contract Raffle is VRFConsumerBaseV2, AutomationCompatibleInterface {
         s_raffleState = RaffleState.OPEN;
         s_lastTimeStamp = block.timestamp;
         i_callbackGasLimit = callbackGasLimit;
-        payable(msg.sender).transfer(address(this).balance);
+        uint256 balance = address(this).balance;
+        if (balance > 0) {
+            payable(msg.sender).transfer(balance);
+        }
     }
 
     function enterRaffle() public payable {


### PR DESCRIPTION
The raffle contract gets deployed to address '0xA8452Ec99ce0C64f20701dB7dD3abDb607c00496'. Refer these two issues #29 #42.
and there is 0.04 ETH (40000000000000000 wei) on that address. See this [etherscan](https://sepolia.etherscan.io/address/0xA8452Ec99ce0C64f20701dB7dD3abDb607c00496)
That's why that testPerformUpkeepRevertsIfCheckUpkeepIsFalse test function fails on Sepolia forked network.
So you'll need to add below to the constructor function to clear balance when deploying.
```
uint256 balance = address(this).balance;
if (balance > 0) {
    payable(msg.sender).transfer(balance);
}
```

The issues #29 #42 are already closed without appropriate correction.