### PR TITLE
Added testCheckUpkeepReturnsFalseIfEnoughTimeHasntPassed logic

### DIFF
--- a/test/unit/RaffleTest.t.sol
+++ b/test/unit/RaffleTest.t.sol
@@ -129,7 +129,15 @@ contract RaffleTest is StdCheats, Test {
     }
 
     // Can you implement this?
-    function testCheckUpkeepReturnsFalseIfEnoughTimeHasntPassed() public {}
+    function testCheckUpkeepReturnsFalseIfEnoughTimeHasntPassed() public {
+        vm.prank(PLAYER);
+        raffle.enterRaffle{value: raffleEntranceFee}();
+        vm.warp(20); //Lesser than the interval ie 30
+        vm.roll(block.number + 1);
+
+        (bool upKeepNeeded, ) = raffle.checkUpkeep("");
+        assert(!upKeepNeeded);
+    }
 
     function testCheckUpkeepReturnsTrueWhenParametersGood() public {
         // Arrange


### PR DESCRIPTION
Adding Logic to the testCheckUpkeepReturnsFalseIfEnoughTimeHasntPassed.
The logic warps time after entering in the raffle and it warps lesser than the Determined Interval and hence the checkupkeep is returned False